### PR TITLE
docs: improve README and documentation

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,6 +1,7 @@
 # Código de Conduta do dx-cli
 
 Este projeto adota o [Contributor Covenant v2.1](https://www.contributor-covenant.org/version/2/1/code_of_conduct/) como base. Queremos um ambiente aberto, acolhedor e profissional.
+Questões gerais sobre o Código de Conduta podem ser tratadas nas issues.
 
 > EN: This Code of Conduct is primarily in Portuguese. See the original Contributor Covenant for an English reference; contributions to a full EN version here are welcome.
 
@@ -27,6 +28,7 @@ Este projeto adota o [Contributor Covenant v2.1](https://www.contributor-covenan
 ## Como reportar
 - Para assuntos sensíveis, utilize o processo descrito em [SECURITY.md](SECURITY.md) (GitHub Security Advisories ou canal privado). Evite expor dados sensíveis em issues públicas.
 - Descreva o ocorrido de forma objetiva (datas, links, contexto) sem divulgar informações pessoais desnecessárias.
+- Para dúvidas ou esclarecimentos, abra uma issue.
 
 ## Aplicação
 - A manutenção do projeto avaliará incidentes de boa-fé e poderá tomar ações que vão de orientação a restrições temporárias ou permanentes de participação.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,7 +27,7 @@ Obrigado por considerar contribuir! Este projeto tem foco em DX e colaboração 
 - Mantemos o main simples; lógica complexa pode ir para `src/lib.rs` no futuro para facilitar testes.
 
 ## Formas de contribuir
-- Correções de bugs, melhorias de DX, documentação e testes.
+- Correções de bugs, melhorias de DX, documentação e traduções.
 - Issues: reporte bugs, proponha features, compartilhe casos de uso.
 - PRs pequenos e focados são mais fáceis de revisar.
 
@@ -43,6 +43,7 @@ Obrigado por considerar contribuir! Este projeto tem foco em DX e colaboração 
   - `sudo apt-get update && sudo apt-get install -y build-essential pkg-config libssl-dev`.
   - Instale Rust via rustup (`curl https://sh.rustup.rs -sSf | sh`).
 - Alternativa (Windows): GNU toolchain com MinGW-w64 (menos recomendado no Windows).
+- Verifique a instalação com `rustc --version`.
 
 Comandos úteis do rustup (todas as plataformas):
 ```sh

--- a/README.md
+++ b/README.md
@@ -48,6 +48,12 @@ deploy.
 - [Agradecimentos](#agradecimentos)
 - [English Summary](#english-summary)
 
+## Visão geral
+
+O **dx-cli** é uma CLI em Rust focada em aprimorar a experiência de desenvolvimento em qualquer stack.
+Ele detecta dependências de serviços, gera manifestos de Dev Services e oferece subcomandos para
+portal, testes, configuração, governança e telemetria.
+
 ## Mudanças Recentes
 
 - Kafka UI: porta padrão alterada para 9093 (antes 8080). O compose expõe 9093 e a aplicação define SERVER_PORT=9093 por padrão.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -24,6 +24,7 @@ Obrigado por ajudar a manter o ecossistema seguro. Este documento descreve como 
 - Preferencial: GitHub Security Advisory (aba "Security" do repositório) para enviar um relatório privado.
 - Se indisponível: abra uma Issue sucinta solicitando canal privado. Não publique detalhes técnicos nem PoCs.
 - Evite abrir Pull Requests públicos com correções antes de coordenação privada.
+- Para perguntas gerais sem detalhes sensíveis, utilize issues públicas.
 
 ## Conteúdo mínimo do relatório
 - Descrição clara do problema e impacto potencial.

--- a/test-projects/flink/README.md
+++ b/test-projects/flink/README.md
@@ -7,4 +7,4 @@
 
 Este é um projeto de exemplo para validar a detecção de dependências (Flink, Kafka, Postgres, etc.).
 
-Use `dx-cli dev-badges` para inserir badges automaticamente aqui.
+Use `dx-cli dev-badges` para atualizar as badges automaticamente.

--- a/test-projects/go/README.md
+++ b/test-projects/go/README.md
@@ -7,4 +7,4 @@
 
 Projeto de exemplo em Go para validação de detecção (MongoDB, Kafka).
 
-Execute `dx-cli dev-badges` para inserir badges automaticamente.
+Use `dx-cli dev-badges` para atualizar as badges automaticamente.

--- a/test-projects/java-gradle/README.md
+++ b/test-projects/java-gradle/README.md
@@ -7,5 +7,4 @@
 
 Projeto de exemplo em Java (Gradle) para validação de detecção (Postgres, Kafka).
 
-Abaixo há um bloco de badges previamente existente para validar o comportamento de sobrescrita:
-
+Use `dx-cli dev-badges` para atualizar as badges automaticamente.

--- a/test-projects/java-maven/README.md
+++ b/test-projects/java-maven/README.md
@@ -7,4 +7,4 @@
 
 Projeto de exemplo em Java (Maven) para validação de detecção (Postgres, Kafka).
 
-Rode `dx-cli dev-badges` para inserir os badges.
+Use `dx-cli dev-badges` para atualizar as badges automaticamente.

--- a/test-projects/nodejs/README.md
+++ b/test-projects/nodejs/README.md
@@ -1,7 +1,9 @@
-# Projeto
+# Node.js Sample Project
 <!-- dx-cli:badges:start -->
 [![MongoDB](https://img.shields.io/badge/MongoDB-Dev_Service-green?logo=mongodb)](#) [![Redis](https://img.shields.io/badge/Redis-Dev_Service-red?logo=redis)](#) [![dx-cli](https://img.shields.io/badge/dx--anywhere-CLI-blueviolet)](#)
 <!-- dx-cli:badges:end -->
 
+Projeto de exemplo em Node.js para validação de detecção (MongoDB, Redis).
 
+Use `dx-cli dev-badges` para atualizar as badges automaticamente.
 

--- a/test-projects/php/README.md
+++ b/test-projects/php/README.md
@@ -3,8 +3,7 @@
 [![MySQL](https://img.shields.io/badge/MySQL-Dev_Service-blue?logo=mysql)](#) [![Redis](https://img.shields.io/badge/Redis-Dev_Service-red?logo=redis)](#) [![dx-cli](https://img.shields.io/badge/dx--anywhere-CLI-blueviolet)](#)
 <!-- dx-cli:badges:end -->
 
-
-
 Projeto de exemplo em PHP para validação de detecção (MySQL/MariaDB, Redis).
 
-Execute `dx-cli dev-badges` para inserir badges neste arquivo.
+Use `dx-cli dev-badges` para atualizar as badges automaticamente.
+

--- a/test-projects/python/README.md
+++ b/test-projects/python/README.md
@@ -3,8 +3,7 @@
 [![PostgreSQL](https://img.shields.io/badge/PostgreSQL-Dev_Service-blue?logo=postgresql)](#) [![Redis](https://img.shields.io/badge/Redis-Dev_Service-red?logo=redis)](#) [![dx-cli](https://img.shields.io/badge/dx--anywhere-CLI-blueviolet)](#)
 <!-- dx-cli:badges:end -->
 
-
-
 Projeto de exemplo em Python para validação de detecção (Postgres, Redis).
 
-Use `dx-cli dev-badges` para inserir badges automaticamente.
+Use `dx-cli dev-badges` para atualizar as badges automaticamente.
+

--- a/test-projects/ruby/README.md
+++ b/test-projects/ruby/README.md
@@ -3,8 +3,7 @@
 [![PostgreSQL](https://img.shields.io/badge/PostgreSQL-Dev_Service-blue?logo=postgresql)](#) [![Redis](https://img.shields.io/badge/Redis-Dev_Service-red?logo=redis)](#) [![dx-cli](https://img.shields.io/badge/dx--anywhere-CLI-blueviolet)](#)
 <!-- dx-cli:badges:end -->
 
-
-
 Projeto de exemplo em Ruby para validação de detecção (Postgres, Redis).
 
-Rode `dx-cli dev-badges` para inserir badges automaticamente.
+Use `dx-cli dev-badges` para atualizar as badges automaticamente.
+


### PR DESCRIPTION
## Summary
- add overview section to README
- clarify code of conduct, contributing guide, and security policy
- standardize sample project README badges and descriptions

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings` *(fails: unnecessary `if let` since only the `Ok` variant of the iterator element is used; this exists prior to docs changes)*
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68ab9abd83808330af956879591e4479