### PR TITLE
feat: add dev-test command

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,3 +12,4 @@ path = "src/main.rs"
 
 [dependencies]
 clap = { version = "4", features = ["derive"] }
+notify = "6"

--- a/README.md
+++ b/README.md
@@ -68,8 +68,8 @@ portal, testes, configuração, governança e telemetria.
 
 ## Funcionalidades
 
-- CLI em Rust com subcomandos para: dev-services, portal, tests, config, docs, governance,
-  telemetry.
+- CLI em Rust com subcomandos para: dev-services, dev-test, portal, tests, config, docs,
+  governance, telemetry.
 - Detecção de dependências de serviços comuns (PostgreSQL, Kafka, Redis, MongoDB) e geração de
   manifesto Docker Compose.
 - Suporte a testes de detecção em múltiplas linguagens por meio de projetos de exemplo.
@@ -243,12 +243,14 @@ rustup default stable
 - Analisador (analyzer/doctor): `dx analyzer` (alias: `dx doctor`)
 - Dev Badges (inserir badges detectadas): `dx dev-badges [--no-save] [<dir>]`
 - Dev Badges (limpar badges): `dx dev-badges clean [<dir>]`
+- Dev Test (vigia arquivos e executa testes): `dx dev-test [<dir>]`
 - Limpar pastas .dx recursivamente: `dx clean [<dir>]`
 
 Subcomandos disponíveis:
 
 - dev-services (com ações: run, stop, restart, remove)
 - dev-badges (com ação: clean)
+- dev-test
 - portal
 - tests
 - config
@@ -258,6 +260,13 @@ Subcomandos disponíveis:
 - clean
 
 Execute `dx <subcomando> --help` para ver opções específicas.
+
+### dev-test
+
+O subcomando `dev-test` monitora o diretório do projeto e relança os testes
+unitários sempre que detectar alterações nos arquivos. A stack é identificada
+automaticamente (Rust, Node.js, Python, Go ou Java) para escolher o comando de
+teste apropriado. Use `Ctrl-C` para encerrar o monitoramento.
 
 ## Analyzer (Analisador de Projeto)
 
@@ -484,9 +493,10 @@ concept, testing aids, configuration, docs, governance and telemetry stubs.
 
 - Build (all platforms): `cargo build` (release: `cargo build --release`)
 - Run: `dx --help` or `cargo run -- --help`
-- Subcommands: init; dev-services (actions: run, stop, restart, remove); dev-badges (action: clean); portal; tests; config; docs; governance; analyzer (alias: doctor)
+- Subcommands: init; dev-services (actions: run, stop, restart, remove); dev-badges (action: clean); dev-test; portal; tests; config; docs; governance; analyzer (alias: doctor)
 - Dev Services: scans Cargo.toml and .env to propose services and outputs docker-compose.yml (print
   or save). Then you can: `dx dev-services run|stop|restart|remove`.
+- Continuous tests: `dx dev-test` watches for changes and reruns unit tests (Rust, Node.js, Python, Go or Java).
 
 Contributions are welcome. See CONTRIBUTING.md and CODE_OF_CONDUCT.md. Licensed under MIT or
 Apache-2.0.

--- a/src/dev_test.rs
+++ b/src/dev_test.rs
@@ -1,0 +1,149 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+// Copyright (c) 2025 The dx-cli Contributors
+
+use std::{
+    fmt,
+    path::{Path, PathBuf},
+    process::Command,
+    sync::mpsc::channel,
+    time::{Duration, Instant},
+};
+
+use notify::{recommended_watcher, EventKind, RecursiveMode, Watcher};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Stack {
+    Rust,
+    Node,
+    Python,
+    Go,
+    JavaMaven,
+    JavaGradle,
+    Unknown,
+}
+
+impl Stack {
+    fn detect(dir: &Path) -> Self {
+        if dir.join("Cargo.toml").exists() {
+            Stack::Rust
+        } else if dir.join("package.json").exists() {
+            Stack::Node
+        } else if dir.join("pyproject.toml").exists() || dir.join("requirements.txt").exists() {
+            Stack::Python
+        } else if dir.join("go.mod").exists() {
+            Stack::Go
+        } else if dir.join("pom.xml").exists() {
+            Stack::JavaMaven
+        } else if dir.join("build.gradle").exists() || dir.join("build.gradle.kts").exists() {
+            Stack::JavaGradle
+        } else {
+            Stack::Unknown
+        }
+    }
+
+    fn test_command(self, dir: &Path) -> Option<(String, Vec<String>)> {
+        match self {
+            Stack::Rust => Some(("cargo".into(), vec!["test".into()])),
+            Stack::Node => Some(("npm".into(), vec!["test".into()])),
+            Stack::Python => Some(("python".into(), vec!["-m".into(), "pytest".into()])),
+            Stack::Go => Some(("go".into(), vec!["test".into(), "./...".into()])),
+            Stack::JavaMaven => Some(("mvn".into(), vec!["test".into()])),
+            Stack::JavaGradle => {
+                if dir.join("gradlew").exists() {
+                    Some(("./gradlew".into(), vec!["test".into()]))
+                } else {
+                    Some(("gradle".into(), vec!["test".into()]))
+                }
+            }
+            Stack::Unknown => None,
+        }
+    }
+}
+
+impl fmt::Display for Stack {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let name = match self {
+            Stack::Rust => "Rust",
+            Stack::Node => "Node.js",
+            Stack::Python => "Python",
+            Stack::Go => "Go",
+            Stack::JavaMaven => "Java (Maven)",
+            Stack::JavaGradle => "Java (Gradle)",
+            Stack::Unknown => "Desconhecida",
+        };
+        write!(f, "{name}")
+    }
+}
+
+fn run_tests(dir: &Path, cmd: &str, args: &[String]) {
+    println!("> Executando testes: {} {:?}", cmd, args);
+    match Command::new(cmd).args(args).current_dir(dir).status() {
+        Ok(status) if status.success() => println!("> Testes concluídos com sucesso"),
+        Ok(status) => println!("> Testes falharam (status {status})"),
+        Err(e) => eprintln!("Erro ao executar comando de teste: {e}"),
+    }
+}
+
+fn should_ignore(path: &Path) -> bool {
+    path.components().any(|comp| {
+        matches!(
+            comp.as_os_str().to_str(),
+            Some(c) if c.starts_with('.') || c == "target" || c == "node_modules"
+        )
+    })
+}
+
+/// Watch files in `dir` and re-run unit tests on changes.
+/// Detects the project stack automatically to choose the test command.
+pub fn watch_and_test(dir: Option<PathBuf>) {
+    let project_dir =
+        dir.unwrap_or_else(|| std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".")));
+    let stack = Stack::detect(&project_dir);
+    let Some((cmd, args)) = stack.test_command(&project_dir) else {
+        eprintln!("Stack não reconhecida em {}", project_dir.display());
+        return;
+    };
+
+    println!("Stack detectada: {}", stack);
+    println!(
+        "Monitorando alterações em {} (Ctrl-C para sair)",
+        project_dir.display()
+    );
+
+    run_tests(&project_dir, &cmd, &args);
+
+    let (tx, rx) = channel();
+
+    let mut watcher = recommended_watcher(move |res| {
+        tx.send(res).ok();
+    })
+    .expect("não foi possível iniciar watcher");
+
+    watcher
+        .watch(&project_dir, RecursiveMode::Recursive)
+        .expect("não foi possível observar diretório");
+
+    const DEBOUNCE_MS: u64 = 500;
+    let mut last_run = Instant::now();
+
+    for res in rx {
+        match res {
+            Ok(event) => {
+                if matches!(
+                    event.kind,
+                    EventKind::Create(_) | EventKind::Modify(_) | EventKind::Remove(_)
+                ) {
+                    if event.paths.iter().any(|p| !should_ignore(p))
+                        && last_run.elapsed() >= Duration::from_millis(DEBOUNCE_MS)
+                    {
+                        last_run = Instant::now();
+                        println!("Alterações detectadas. Executando testes...");
+                        run_tests(&project_dir, &cmd, &args);
+                    }
+                }
+            }
+            Err(e) => eprintln!("Erro do watcher: {e}"),
+        }
+    }
+}
+

--- a/src/main.rs
+++ b/src/main.rs
@@ -39,6 +39,11 @@ enum Commands {
         /// Diretório alvo (padrão: diretório atual). Para `clean`, também pode ser informado após o subcomando.
         dir: Option<std::path::PathBuf>,
     },
+    /// Executa testes unitários continuamente ao detectar mudanças nos arquivos
+    DevTest {
+        /// Diretório raiz do projeto a ser monitorado (opcional; padrão: diretório atual)
+        dir: Option<std::path::PathBuf>,
+    },
     /// Portal/plug-in do desenvolvedor (Dev UI)
     Portal,
     /// Testes contínuos e inteligentes (geração/execução)
@@ -104,6 +109,7 @@ enum DevServicesAction {
 
 
 mod dev_badges;
+mod dev_test;
 
 fn main() {
     let cli = Cli::parse();
@@ -123,6 +129,7 @@ fn main() {
                 None => cmd_dev_badges(!no_save, dir),
             }
         }
+        Commands::DevTest { dir } => dev_test::watch_and_test(dir),
         Commands::Portal => cmd_portal(),
         Commands::Tests => cmd_tests(),
         Commands::Config => cmd_config(),
@@ -571,6 +578,7 @@ fn cmd_portal() {
         "Portal do Dev (stub)\n- Gerir configs, semear dados, publicar eventos, inspecionar logs/telemetria e acionar fluxos comuns.\n- Exemplos orientados por IA: 'publique 500 eventos válidos neste tópico', 'gere massa de dados conforme este schema'."
     );
 }
+
 
 fn cmd_tests() {
     println!(

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -17,6 +17,7 @@ fn help_lists_subcommands() {
     // Subcommands (kebab-case by default via clap derive)
     for sub in [
         "dev-services",
+        "dev-test",
         "portal",
         "tests",
         "config",


### PR DESCRIPTION
## Summary
- modularize `dev-test` into its own watcher module
- document continuous testing usage and add `notify` dependency

## Testing
- `cargo test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed / 403)*

------
https://chatgpt.com/codex/tasks/task_e_68acef2abec88330b2c22ee3bd91dcc5