### PR TITLE
feat: manage stack configs via dev-services

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,3 +13,6 @@ path = "src/main.rs"
 [dependencies]
 clap = { version = "4", features = ["derive"] }
 notify = "6"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+serde_yaml = "0.9"

--- a/src/dev_services_config.rs
+++ b/src/dev_services_config.rs
@@ -1,0 +1,141 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+// Copyright (c) 2025 The dx-cli Contributors
+use std::collections::BTreeMap;
+use std::env;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use clap::ValueEnum;
+use serde::{Deserialize, Serialize};
+
+const CONFIG_FILE: &str = "properties.yaml";
+
+#[derive(ValueEnum, Clone)]
+pub enum DevConfigSection {
+    Config,
+    Env,
+    Priority,
+}
+
+#[derive(Serialize, Deserialize, Default)]
+pub struct StackConfig {
+    #[serde(default)]
+    pub configs: BTreeMap<String, String>,
+    #[serde(default)]
+    pub env: BTreeMap<String, String>,
+    #[serde(default)]
+    pub priorities: BTreeMap<String, i64>,
+}
+
+fn config_path(project_dir: &Path, stack: &str) -> PathBuf {
+    project_dir.join(".dx").join(stack).join(CONFIG_FILE)
+}
+
+fn load_config(project_dir: &Path, stack: &str) -> std::io::Result<StackConfig> {
+    let path = config_path(project_dir, stack);
+    if path.exists() {
+        let content = fs::read_to_string(path)?;
+        serde_yaml::from_str(&content)
+            .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))
+    } else {
+        Ok(StackConfig::default())
+    }
+}
+
+fn save_config(project_dir: &Path, stack: &str, cfg: &StackConfig) -> std::io::Result<()> {
+    let path = config_path(project_dir, stack);
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    let content = serde_yaml::to_string(cfg)
+        .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?;
+    fs::write(path, content)
+}
+
+fn resolve_dir(dir: Option<PathBuf>) -> PathBuf {
+    dir.unwrap_or_else(|| env::current_dir().unwrap_or_else(|_| PathBuf::from(".")))
+}
+
+fn resolve_stack(stack: Option<String>) -> String {
+    stack.unwrap_or_else(|| "default".to_string())
+}
+
+pub fn list(dir: Option<PathBuf>, stack: Option<String>) {
+    let project_dir = resolve_dir(dir);
+    let stack_name = resolve_stack(stack);
+    match load_config(&project_dir, &stack_name) {
+        Ok(cfg) => match serde_yaml::to_string(&cfg) {
+            Ok(yaml) => println!("{}", yaml),
+            Err(e) => eprintln!("Erro ao serializar configuração: {}", e),
+        },
+        Err(e) => eprintln!("Erro ao carregar configuração: {}", e),
+    }
+}
+
+pub fn set(
+    dir: Option<PathBuf>,
+    stack: Option<String>,
+    section: DevConfigSection,
+    key: String,
+    value: String,
+) {
+    let project_dir = resolve_dir(dir);
+    let stack_name = resolve_stack(stack);
+    let mut cfg = match load_config(&project_dir, &stack_name) {
+        Ok(c) => c,
+        Err(e) => {
+            eprintln!("Erro ao carregar configuração: {}", e);
+            return;
+        }
+    };
+
+    match section {
+        DevConfigSection::Config => {
+            cfg.configs.insert(key, value);
+        }
+        DevConfigSection::Env => {
+            cfg.env.insert(key, value);
+        }
+        DevConfigSection::Priority => match value.parse::<i64>() {
+            Ok(v) => {
+                cfg.priorities.insert(key, v);
+            }
+            Err(_) => {
+                eprintln!("Valor de prioridade deve ser um número inteiro");
+                return;
+            }
+        },
+    }
+
+    if let Err(e) = save_config(&project_dir, &stack_name, &cfg) {
+        eprintln!("Erro ao salvar configuração: {}", e);
+    }
+}
+
+pub fn remove(dir: Option<PathBuf>, stack: Option<String>, section: DevConfigSection, key: String) {
+    let project_dir = resolve_dir(dir);
+    let stack_name = resolve_stack(stack);
+    let mut cfg = match load_config(&project_dir, &stack_name) {
+        Ok(c) => c,
+        Err(e) => {
+            eprintln!("Erro ao carregar configuração: {}", e);
+            return;
+        }
+    };
+
+    match section {
+        DevConfigSection::Config => {
+            cfg.configs.remove(&key);
+        }
+        DevConfigSection::Env => {
+            cfg.env.remove(&key);
+        }
+        DevConfigSection::Priority => {
+            cfg.priorities.remove(&key);
+        }
+    }
+
+    if let Err(e) = save_config(&project_dir, &stack_name, &cfg) {
+        eprintln!("Erro ao salvar configuração: {}", e);
+    }
+}

--- a/tests/dev_services_config.rs
+++ b/tests/dev_services_config.rs
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+use std::env;
+use std::fs;
+use std::process::Command;
+
+#[test]
+fn dev_services_config_set_list_remove() {
+    let exe = env!("CARGO_BIN_EXE_dx");
+    let temp_dir = env::temp_dir().join("dx-cli-dev-services-config-test");
+    let _ = fs::remove_dir_all(&temp_dir);
+    fs::create_dir_all(&temp_dir).expect("criar diretório de teste");
+
+    // Set an env variable
+    let status = Command::new(exe)
+        .current_dir(&temp_dir)
+        .arg("dev-services")
+        .arg("config")
+        .arg("set")
+        .arg("env")
+        .arg("API_KEY")
+        .arg("123")
+        .arg("--stack")
+        .arg("spring-boot")
+        .status()
+        .expect("executar dev-services config set");
+    assert!(status.success());
+
+    // List and check presence
+    let output = Command::new(exe)
+        .current_dir(&temp_dir)
+        .arg("dev-services")
+        .arg("config")
+        .arg("list")
+        .arg("--stack")
+        .arg("spring-boot")
+        .output()
+        .expect("executar dev-services config list");
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("API_KEY: 123"));
+
+    // Remove the variable
+    let status = Command::new(exe)
+        .current_dir(&temp_dir)
+        .arg("dev-services")
+        .arg("config")
+        .arg("remove")
+        .arg("env")
+        .arg("API_KEY")
+        .arg("--stack")
+        .arg("spring-boot")
+        .status()
+        .expect("executar dev-services config remove");
+    assert!(status.success());
+
+    // Ensure removal
+    let output = Command::new(exe)
+        .current_dir(&temp_dir)
+        .arg("dev-services")
+        .arg("config")
+        .arg("list")
+        .arg("--stack")
+        .arg("spring-boot")
+        .output()
+        .expect("executar dev-services config list 2");
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(!stdout.contains("API_KEY"));
+
+    let _ = fs::remove_dir_all(&temp_dir);
+}


### PR DESCRIPTION
## Summary
- move config management under `dx dev-services config`
- store per-stack settings in `.dx/<stack>/properties.yaml`
- cover Spring Boot properties with listing, setting and removal tests

## Testing
- `cargo test` *(failed: failed to download from `https://index.crates.io/config.json`)*

------
https://chatgpt.com/codex/tasks/task_e_68acf4321fa083308dc66eb04d9b7dd1