### PR TITLE
feat: manage project configurations

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,3 +13,8 @@ path = "src/main.rs"
 [dependencies]
 clap = { version = "4", features = ["derive"] }
 notify = "6"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+
+[dev-dependencies]
+tempfile = "3"

--- a/src/dev_config.rs
+++ b/src/dev_config.rs
@@ -1,0 +1,158 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+// Copyright (c) 2025 The dx-cli Contributors
+
+use serde::{Deserialize, Serialize};
+use std::{
+    collections::BTreeMap,
+    fmt,
+    fs,
+    path::{Path, PathBuf},
+};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Stack {
+    Rust,
+    Node,
+    Python,
+    Go,
+    JavaMaven,
+    JavaGradle,
+    Unknown,
+}
+
+impl Stack {
+    fn detect(dir: &Path) -> Self {
+        if dir.join("Cargo.toml").exists() {
+            Stack::Rust
+        } else if dir.join("package.json").exists() {
+            Stack::Node
+        } else if dir.join("pyproject.toml").exists() || dir.join("requirements.txt").exists() {
+            Stack::Python
+        } else if dir.join("go.mod").exists() {
+            Stack::Go
+        } else if dir.join("pom.xml").exists() {
+            Stack::JavaMaven
+        } else if dir.join("build.gradle").exists() || dir.join("build.gradle.kts").exists() {
+            Stack::JavaGradle
+        } else {
+            Stack::Unknown
+        }
+    }
+}
+
+impl fmt::Display for Stack {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let name = match self {
+            Stack::Rust => "Rust",
+            Stack::Node => "Node.js",
+            Stack::Python => "Python",
+            Stack::Go => "Go",
+            Stack::JavaMaven => "Java (Maven)",
+            Stack::JavaGradle => "Java (Gradle)",
+            Stack::Unknown => "Desconhecida",
+        };
+        write!(f, "{name}")
+    }
+}
+
+#[derive(Serialize, Deserialize, Default)]
+struct Config(BTreeMap<String, String>);
+
+impl Config {
+    fn load(path: &Path) -> Self {
+        if let Ok(data) = fs::read_to_string(path) {
+            serde_json::from_str(&data).unwrap_or_default()
+        } else {
+            Config::default()
+        }
+    }
+
+    fn save(&self, path: &Path) -> std::io::Result<()> {
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent)?;
+        }
+        let data = serde_json::to_string_pretty(self).unwrap();
+        fs::write(path, data)
+    }
+}
+
+fn config_path(project_dir: &Path) -> PathBuf {
+    project_dir.join(".dx").join("config.json")
+}
+
+fn project_dir(dir: Option<PathBuf>) -> PathBuf {
+    dir.unwrap_or_else(|| std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".")))
+}
+
+pub fn list(dir: Option<PathBuf>) {
+    let project_dir = project_dir(dir);
+    let stack = Stack::detect(&project_dir);
+    println!("Stack detectada: {}", stack);
+
+    let path = config_path(&project_dir);
+    let cfg = Config::load(&path);
+    if cfg.0.is_empty() {
+        println!("Nenhuma configuração encontrada.");
+    } else {
+        for (k, v) in cfg.0 {
+            println!("- {k} = {v}");
+        }
+    }
+}
+
+pub fn add(dir: Option<PathBuf>, key: String, value: String) {
+    let project_dir = project_dir(dir);
+    let stack = Stack::detect(&project_dir);
+    println!("Stack detectada: {}", stack);
+
+    let path = config_path(&project_dir);
+    let mut cfg = Config::load(&path);
+    if cfg.0.contains_key(&key) {
+        println!("Configuração '{key}' já existe.");
+        return;
+    }
+    cfg.0.insert(key.clone(), value);
+    if let Err(e) = cfg.save(&path) {
+        eprintln!("Erro ao salvar configurações: {e}");
+    } else {
+        println!("Configuração '{key}' criada.");
+    }
+}
+
+pub fn update(dir: Option<PathBuf>, key: String, value: String) {
+    let project_dir = project_dir(dir);
+    let stack = Stack::detect(&project_dir);
+    println!("Stack detectada: {}", stack);
+
+    let path = config_path(&project_dir);
+    let mut cfg = Config::load(&path);
+    if !cfg.0.contains_key(&key) {
+        println!("Configuração '{key}' não existe.");
+        return;
+    }
+    cfg.0.insert(key.clone(), value);
+    if let Err(e) = cfg.save(&path) {
+        eprintln!("Erro ao salvar configurações: {e}");
+    } else {
+        println!("Configuração '{key}' atualizada.");
+    }
+}
+
+pub fn delete(dir: Option<PathBuf>, key: String) {
+    let project_dir = project_dir(dir);
+    let stack = Stack::detect(&project_dir);
+    println!("Stack detectada: {}", stack);
+
+    let path = config_path(&project_dir);
+    let mut cfg = Config::load(&path);
+    if cfg.0.remove(&key).is_some() {
+        if let Err(e) = cfg.save(&path) {
+            eprintln!("Erro ao salvar configurações: {e}");
+        } else {
+            println!("Configuração '{key}' removida.");
+        }
+    } else {
+        println!("Configuração '{key}' não existe.");
+    }
+}
+

--- a/src/main.rs
+++ b/src/main.rs
@@ -44,6 +44,14 @@ enum Commands {
         /// Diretório raiz do projeto a ser monitorado (opcional; padrão: diretório atual)
         dir: Option<std::path::PathBuf>,
     },
+    /// Gerencia configurações do projeto e identifica a stack
+    DevConfig {
+        /// Ação opcional (ex.: `add`). Se omitida, lista configurações.
+        #[command(subcommand)]
+        action: Option<DevConfigAction>,
+        /// Diretório raiz do projeto (opcional; padrão: diretório atual)
+        dir: Option<std::path::PathBuf>,
+    },
     /// Portal/plug-in do desenvolvedor (Dev UI)
     Portal,
     /// Testes contínuos e inteligentes (geração/execução)
@@ -107,8 +115,34 @@ enum DevServicesAction {
     },
 }
 
+#[derive(Subcommand)]
+enum DevConfigAction {
+    /// Lista todas as configurações
+    List,
+    /// Cria nova configuração
+    Add {
+        /// Chave da configuração
+        key: String,
+        /// Valor da configuração
+        value: String,
+    },
+    /// Atualiza configuração existente
+    Update {
+        /// Chave da configuração
+        key: String,
+        /// Novo valor da configuração
+        value: String,
+    },
+    /// Remove uma configuração
+    Delete {
+        /// Chave da configuração
+        key: String,
+    },
+}
+
 
 mod dev_badges;
+mod dev_config;
 mod dev_test;
 
 fn main() {
@@ -130,6 +164,12 @@ fn main() {
             }
         }
         Commands::DevTest { dir } => dev_test::watch_and_test(dir),
+        Commands::DevConfig { action, dir } => match action.unwrap_or(DevConfigAction::List) {
+            DevConfigAction::List => dev_config::list(dir),
+            DevConfigAction::Add { key, value } => dev_config::add(dir, key, value),
+            DevConfigAction::Update { key, value } => dev_config::update(dir, key, value),
+            DevConfigAction::Delete { key } => dev_config::delete(dir, key),
+        },
         Commands::Portal => cmd_portal(),
         Commands::Tests => cmd_tests(),
         Commands::Config => cmd_config(),

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -1,4 +1,5 @@
 use std::process::Command;
+use std::fs;
 
 #[test]
 fn help_lists_subcommands() {
@@ -18,6 +19,7 @@ fn help_lists_subcommands() {
     for sub in [
         "dev-services",
         "dev-test",
+        "dev-config",
         "portal",
         "tests",
         "config",
@@ -26,4 +28,53 @@ fn help_lists_subcommands() {
     ] {
         assert!(stdout.contains(sub), "missing subcommand in help: {}", sub);
     }
+}
+
+#[test]
+fn dev_config_lists_configs() {
+    let exe = env!("CARGO_BIN_EXE_dx");
+    let output = Command::new(exe)
+        .args(["dev-config", "list"])
+        .current_dir("test-projects/nodejs")
+        .output()
+        .expect("failed to run dx dev-config list");
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("Stack detectada"));
+}
+
+#[test]
+fn dev_config_add_update_delete() {
+    let exe = env!("CARGO_BIN_EXE_dx");
+    let tmp = tempfile::tempdir().expect("tempdir");
+    fs::write(tmp.path().join("Cargo.toml"), "[package]\nname=\"tmp\"\nversion=\"0.1.0\"").unwrap();
+
+    let status = Command::new(exe)
+        .args(["dev-config", "add", "foo", "bar"])
+        .current_dir(tmp.path())
+        .status()
+        .expect("failed to run add");
+    assert!(status.success());
+
+    let path = tmp.path().join(".dx").join("config.json");
+    let contents = fs::read_to_string(&path).expect("read config");
+    assert!(contents.contains("\"foo\": \"bar\""));
+
+    let status = Command::new(exe)
+        .args(["dev-config", "update", "foo", "baz"])
+        .current_dir(tmp.path())
+        .status()
+        .expect("failed to run update");
+    assert!(status.success());
+    let contents = fs::read_to_string(&path).expect("read config");
+    assert!(contents.contains("\"foo\": \"baz\""));
+
+    let status = Command::new(exe)
+        .args(["dev-config", "delete", "foo"])
+        .current_dir(tmp.path())
+        .status()
+        .expect("failed to run delete");
+    assert!(status.success());
+    let contents = fs::read_to_string(&path).expect("read config");
+    assert!(!contents.contains("foo"));
 }


### PR DESCRIPTION
## Summary
- add CRUD subcommands to `dev-config` and persist values in `.dx/config.json`
- wire new `dev-config` actions into the CLI
- cover config management in integration tests

## Testing
- `cargo test` *(fails: failed to download from `https://index.crates.io/config.json`)*

------
https://chatgpt.com/codex/tasks/task_e_68acf87c981c8330a6f2521a71b7b0dc